### PR TITLE
Prepare netty version bump

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -17,7 +17,7 @@
 gradleVersion=1.7
 
 # vert.x version
-version=2.1.6-bm6
+version=2.1.6-bm7
 vertxbusjsVersion=2.1
 testframeworkversion=2.0.0-final
 title=vert.x
@@ -27,7 +27,7 @@ group=io.vertx
 hazelcastVersion=3.8.2
 jacksonCoreVersion=2.2.2
 jacksonDatabindVersion=2.2.2
-nettyVersion=4.0.33.Final
+nettyVersion=4.0.48.Final
 log4jVersion=1.2.16
 slf4jVersion=1.6.2
 junitVersion=4.10


### PR DESCRIPTION
Modif target platform à suivre si tout build comme il faut.
Motivation: un correctif dans la 4.0.41 sur les recycler netty qui peut causer des out-of-direct-memory (investigation suite à pb tony lmtp)