### PR TITLE
UDL-198 Fix: set so_linger correctly after netty upgrade

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -17,7 +17,7 @@
 gradleVersion=1.7
 
 # vert.x version
-version=2.1.6-bm11
+version=2.1.6-bm12
 vertxbusjsVersion=2.1
 testframeworkversion=2.0.0-final
 title=vert.x

--- a/vertx-core/src/main/java/org/vertx/java/core/net/impl/TCPSSLHelper.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/net/impl/TCPSSLHelper.java
@@ -101,7 +101,7 @@ public class TCPSSLHelper {
       bootstrap.childOption(ChannelOption.RCVBUF_ALLOCATOR, new FixedRecvByteBufAllocator(tcpReceiveBufferSize));
     }
 
-    bootstrap.option(ChannelOption.SO_LINGER, soLinger);
+    bootstrap.childOption(ChannelOption.SO_LINGER, soLinger);
     if (trafficClass != -1) {
       bootstrap.childOption(ChannelOption.IP_TOS, trafficClass);
     }


### PR DESCRIPTION
2018-03-02 17:20:09,236 [vert.x-eventloop-thread-0] i.n.b.ServerBootstrap WARN - Unknown channel option 'SO_LINGER' for channel '[id: 0xb4b3adbb]'