### PR TITLE
Feat: remove support for SSLv2Hello

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -17,7 +17,7 @@
 gradleVersion=1.7
 
 # vert.x version
-version=2.1.6-bm20
+version=2.1.6-bm21
 vertxbusjsVersion=2.1
 testframeworkversion=2.0.0-final
 title=vert.x

--- a/vertx-core/src/main/java/org/vertx/java/core/net/impl/TCPSSLHelper.java
+++ b/vertx-core/src/main/java/org/vertx/java/core/net/impl/TCPSSLHelper.java
@@ -376,7 +376,7 @@ public class TCPSSLHelper {
   }
 
   // Make sure SSLv3 is NOT enabled due to POODLE issue http://en.wikipedia.org/wiki/POODLE
-  private static final String[] ENABLED_PROTOCOLS = {"SSLv2Hello", "TLSv1", "TLSv1.1", "TLSv1.2"};
+  private static final String[] ENABLED_PROTOCOLS = {"TLSv1", "TLSv1.1", "TLSv1.2"};
 
   private SslHandler createHandler(SSLEngine engine, boolean client) {
     engine.setEnabledProtocols(ENABLED_PROTOCOLS);


### PR DESCRIPTION
SSLv2Hello is no longer supported by default jdk7 server implementations.
for this reason, clients may block the SSLv2Hello pseudo protocol, see BM-13359
  